### PR TITLE
linux: Convert dup2 calls to dup3

### DIFF
--- a/capture_other.go
+++ b/capture_other.go
@@ -23,11 +23,11 @@ import (
 // CaptureOutputToFd redirects the current process' stdout and stderr file
 // descriptors to the given file descriptor, using the dup2 syscall.
 func CaptureOutputToFd(fd int) error {
-	err := syscall.Dup2(fd, syscall.Stdout)
+	err := syscall.Dup3(fd, syscall.Stdout, 0)
 	if err != nil {
 		return err
 	}
-	err = syscall.Dup2(fd, syscall.Stderr)
+	err = syscall.Dup3(fd, syscall.Stderr, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Convert syscall.Dup2 calls to syscall.Dup3. The dup2 syscall is depreciated
and is not available on some architectures. Fixes build errors like these when
building for arm64:

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>